### PR TITLE
Queue Entire Lists

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1124,10 +1124,27 @@ $(window).load(function() {
 
     return false;
   }, 200, true);
+  
+  var queueList = function(e) {
+    e.preventDefault();
+    var $self = $(this);
+    var target = $self.data('target');
+
+    $( target + ' tr').each(function(el) {
+      var id = $(this).data('track-id');
+      $.post('/playlist', {
+        source: 'soundtrack',
+        id: id
+      }, function(response) {
+        if (soundtrack.debug) console.log(response);
+      });
+    });
+  };
 
   $(document).on('click', '*[data-action=queue-track]', selectTrack);
 
   $(document).on('click', '*[data-action=queue-set]', selectSet );
+  $(document).on('click', '*[data-action=queue-list]', queueList );
 
   $(document).on('click', '*[data-action=launch-playlist-editor]', function(e) {
     e.preventDefault();

--- a/soundtrack.js
+++ b/soundtrack.js
@@ -823,11 +823,12 @@ app.post('/playlist', requireLogin , function(req, res) {
   if (!app.rooms[ req.room ]) return res.send({ status: 'error', message: 'No room to queue to.' });
 
   soundtrack.trackFromSource( req.param('source') , req.param('id') , req.body, function(err, track) {
-    console.log('trackFromSource() callback executing...', err || track._id );
     if (err || !track) {
-      console.log(err);
+      console.error(err);
       return res.send({ status: 'error', message: 'Could not add that track.' });
     }
+    
+    console.log('trackFromSource() callback executing...', err || track._id );
 
     var queueWasEmpty = false;
     if (!app.rooms[ req.room ].playlist.length) {

--- a/views/partials/play-row.jade
+++ b/views/partials/play-row.jade
@@ -1,5 +1,5 @@
 if (typeof(play._track._artist) != 'undefined' && play._track._artist)
-  tr
+  tr(data-track-id="#{play._track._id}")
     td
       if (play._curator)
         a(href="#{play._curator.slug}") #{play._curator.username}

--- a/views/person-plays.jade
+++ b/views/person-plays.jade
@@ -1,6 +1,9 @@
 extends layout
 
 block content
+  .btn-group.pull-right
+    a.btn.btn-mini(href="#", data-action="queue-list", data-target="#play-list") &#9835; queue &raquo;
+
   h1 #{count} Plays By <a href="/#{person.slug}">#{person.username}</a>
     if (room)
       |  in <a href="#{room.index}">#{room.name}</a>
@@ -9,7 +12,7 @@ block content
     h2 Showing #{ plays.length } most recent
     p add <code>?limit=n</code> parameter to list more.
 
-  table.table.tablesorter
+  table.table.tablesorter#play-list
     thead
       tr
         th Who


### PR DESCRIPTION
This adds a new ability to queue an entire list of tracks, and in particular adds the ability to do so from user play pages.  For example, [my most recent 250 plays](https://soundtrack.io/martindale/plays?limit=250).